### PR TITLE
fix debian build and update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,18 @@
 CFLAGS=-Wall -Werror -I.
 LDFLAGS=-L /usr/local/lib -lmosquitto -lconfig
 
-### macOS
+### Linux
 CFLAGS += `pkg-config --cflags lua5.3`
 LDFLAGS += `pkg-config --libs lua5.3`
+LDFLAGS += `pkg-config --libs libbsd`
 BINDIR = /usr/local/bin
 MANDIR  = /usr/local/share/man
+
+### macOS
+# CFLAGS += `pkg-config --cflags lua5.3`
+# LDFLAGS += `pkg-config --libs lua5.3`
+# BINDIR = /usr/local/bin
+# MANDIR  = /usr/local/share/man
 
 ### FreeBSD
 # CFLAGS += /usr/local/include/lua53/

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ make
 #### debian
 
 ```console
-# apt-get install libconfig-dev liblua5.2-dev # or liblua5.3-dev
+# apt-get install libconfig-dev liblua5.3-dev libmosquitto-dev libbsd-dev
 $ make
 ```
 

--- a/msoak.c
+++ b/msoak.c
@@ -19,6 +19,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#ifdef __linux__
+#include <bsd/string.h>
+#endif
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
List additional dependencies (libmosquitto-dev, libbsd-dev) and include libbsd on linux systems.